### PR TITLE
Reverse order of fixed & remaining warnings for CI emails

### DIFF
--- a/report-borked.bash
+++ b/report-borked.bash
@@ -225,13 +225,13 @@ ${wnew[*]/#/
 ${uri_prefix}/${current_rev}/output.html#}
 
 
-}${wold:+Previous warnings still unfixed:
-${wold[*]/#/
+}${wfixed:+Warnings fixed since last run:
+${wfixed[*]/#/
 ${uri_prefix}/${current_rev}/output.html#}
 
 
-}${wfixed:+Warnings fixed since last run:
-${wfixed[*]/#/
+}${wold:+Previous warnings still unfixed:
+${wold[*]/#/
 ${uri_prefix}/${current_rev}/output.html#}
 
 


### PR DESCRIPTION
Whilst there is a long list of warnings on the CI emails, it is
often hard to see what warnings were actually fixed, as they are
several screens down the email. This patch brings them to the top.