### PR TITLE
pull-requests: prep for codeberg support

### DIFF
--- a/pull-request/pull-requests.bash
+++ b/pull-request/pull-requests.bash
@@ -53,14 +53,21 @@ git pull
 
 # check if we have anything to process
 mkdir -p -- "${pull}"
-prid=$( "${SCRIPT_DIR}"/pull-request/scan-pull-requests.py )
+pr=$( "${SCRIPT_DIR}"/pull-request/scan-pull-requests.py )
+forge="${pr%/*}"
+prid="${pr#*/}"
 
-if [[ -n ${prid} ]]; then
-	echo "${prid}" > "${pull}"/current-pr
+if [[ -n ${pr} ]]; then
+	echo "${pr}" > "${pull}"/current-pr
 
 	cd -- "${sync}"
-	ref=refs/pull/${prid}
-	git fetch -f origin "refs/pull/${prid}/head:${ref}"
+	ref=refs/pull/${pr}
+
+	case ${forge} in
+		github) remote="origin" ;;
+		*) echo "unknown forge ${forge}"; exit 1 ;;
+	esac
+	git fetch -f "${remote}" "refs/pull/${prid}/head:${ref}"
 
 	hash=$(git rev-parse "${ref}")
 
@@ -71,14 +78,14 @@ if [[ -n ${prid} ]]; then
 	cd -- tmp
 	git fetch "${sync}" "${ref}:${ref}"
 	# start on top of last common commit, like fast-forward would do
-	git branch "pull-${prid}" "$(git merge-base "${ref}" master)"
-	git checkout -q "pull-${prid}"
+	git branch "pull-${forge}-${prid}" "$(git merge-base "${ref}" master)"
+	git checkout -q "pull-${forge}-${prid}"
 	# copy existing md5-cache (TODO: try to find previous merge commit)
 	rsync -rlpt --delete "${mirror}"/metadata/{dtd,glsa,md5-cache,news,xml-schema} metadata
 
 	# merge the PR on top of cache
 	git tag pre-merge
-	git merge --quiet -m "Merge PR ${prid}" "${ref}"
+	git merge --quiet -m "Merge PR ${pr}" "${ref}"
 
 	# update cache
 	CONFIG_DIR=${pull}/etc/portage
@@ -88,7 +95,7 @@ if [[ -n ${prid} ]]; then
 	cd ..
 	git clone -s "${gentooci}" gentoo-ci
 	cd -- gentoo-ci
-	git checkout -b "pull-${prid}"
+	git checkout -b "pull-${forge}-${prid}"
 	( cd -- "${pull}"/tmp &&
 		time HOME=${pull}/gentoo-ci \
 		timeout -k 30s "${CI_TIMEOUT}" pkgcheck --config "${CONFIG_DIR}" \
@@ -101,12 +108,12 @@ if [[ -n ${prid} ]]; then
 		-w -e -o borked.list *.xml
 
 	git add -- *.xml
-	git diff --cached --quiet --exit-code || git commit -a -m "PR ${prid} @ $(date -u --date="@${ts}" "+%Y-%m-%d %H:%M:%S UTC")"
+	git diff --cached --quiet --exit-code || git commit -a -m "PR ${pr} @ $(date -u --date="@${ts}" "+%Y-%m-%d %H:%M:%S UTC")"
 	pr_hash=$(git rev-parse --short HEAD)
-	git push -f origin "pull-${prid}"
+	git push -f origin "pull-${forge}-${prid}"
 
 	cd -- "${gentooci}"
-	git push -f origin "pull-${prid}"
+	git push -f origin "pull-${forge}-${prid}"
 	curl "https://qa-reports-cdn-origin.gentoo.org/cgi-bin/trigger-pull.cgi?gentoo-ci" || :
 
 	# if we have any breakages...


### PR DESCRIPTION
Prefix all PRs from GitHub in the cache with "github/" so we have a
handle on which forge a given PR number is from.

Also converted all formatted printing to f-strings and ran "ruff
format" on the file scan-pull-requests.py.