### PR TITLE
pull-request/report-pull-request: fix report_url

### DIFF
--- a/pull-request/report-pull-request.py
+++ b/pull-request/report-pull-request.py
@@ -64,7 +64,7 @@ def report_codeberg_pr(
                 for url in borked:
                     body += url
             if pre_borked:
-                body += f"\nThere are existing issues already. Please look into the report to make sure none of them affect the packages in question:\n{report_url}s\n"
+                body += f"\nThere are existing issues already. Please look into the report to make sure none of them affect the packages in question:\n{report_url}\n"
         elif had_broken:
             body += "\nAll QA issues have been fixed!\n"
         else:


### PR DESCRIPTION
A stray 's' had been left in and it breaks the "details" link.