### PR TITLE
pull-request/report-pull-request: remove old CI reports

### DIFF
--- a/pull-request/report-pull-request.py
+++ b/pull-request/report-pull-request.py
@@ -39,6 +39,10 @@ def report_codeberg_pr(
                     had_broken = True
                 elif "Issues inherited from Gentoo" in body:
                     had_broken = True
+                elif "There are existing issues already" in body:
+                    had_broken = True
+                elif "too many broken packages" in body:
+                    had_broken = True
                 else:
                     # skip comments that don't look like CI results
                     continue
@@ -130,6 +134,10 @@ def report_github_pr(
             elif "Issues already there" in co.body:
                 had_broken = True
             elif "Issues inherited from Gentoo" in co.body:
+                had_broken = True
+            elif "There are existing issues already" in co.body:
+                had_broken = True
+            elif "too many broken packages" in co.body:
                 had_broken = True
             else:
                 # skip comments that don't look like CI results


### PR DESCRIPTION
This should ensure that comments posted with borked/pre_borked are also removed.

---

I'm not sure how is has been working on GitHub, maybe I broke something when adding Codeberg support. I've gone for the minimal changes to make the comment removal work, but I was thinking to revisit the logic for removing old CI report comments.