### PR TITLE
pull-request: handle crashes where ref not fetched

### DIFF
--- a/pull-request/pull-requests.bash
+++ b/pull-request/pull-requests.bash
@@ -15,13 +15,12 @@ if [[ -s ${pull}/current-pr ]]; then
 	forge="${pr%/*}"
 	prid="${pr#*/}"
 	cd -- "${sync}"
-	hash=$(git rev-parse "refs/pull/${pr}")
 	case ${forge} in
 		github) pr_repo="${PULL_REQUEST_REPO}";;
 		codeberg) pr_repo="https://codeberg.org/${CODEBERG_REPO}";;
 		*) echo "unknown forge ${forge}"; exit 1;;
 	esac
-	"${SCRIPT_DIR}"/pull-request/set-pull-request-status.py "${forge}" "${hash}" error \
+	"${SCRIPT_DIR}"/pull-request/set-pull-request-status.py "${pr}" \
 		"QA checks crashed. Please rebase and check profile changes for syntax errors."
 	sendmail "${CRONJOB_ADMIN_MAIL}" <<-EOF
 		Subject: Pull request crash: ${pr}

--- a/pull-request/set-pull-request-status.py
+++ b/pull-request/set-pull-request-status.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python
 
+import errno
 import os
 import os.path
 import sys
+import pickle
 
 import github
 from codebergapi import CodebergAPI
@@ -34,12 +36,26 @@ def set_github_pr_status(commit_hash, stat, desc):
     c.create_status(stat, description=desc, context="gentoo-ci")
 
 
-def main(forge, commit_hash, stat, desc):
+def commit_hash_from_db(pr_id):
+    try:
+        with open(os.environ["PULL_REQUEST_DB"], "rb") as f:
+            db = pickle.load(f)
+            return db.get(pr_id)
+    except (IOError, OSError) as e:
+        if e.errno != errno.ENOENT:
+            raise
+
+
+def main(pr_id, stat, desc):
+    forge = pr_id.split("/")[0]
+    commit_hash = commit_hash_from_db(pr_id)
+    if commit_hash is None:
+        return 0
     if forge == "github":
         set_github_pr_status(commit_hash, stat, desc)
     elif forge == "codeberg":
         set_codeberg_pr_status(commit_hash, stat, desc)
-
+    return 0
 
 if __name__ == "__main__":
     sys.exit(main(*sys.argv[1:]))


### PR DESCRIPTION
If a CI run crashes after identifying a PR to process, but before the ref is fetched (fx fails to fetch the remote ref), the current-pr file is left behind and a subsequent run will detect that the previous CI run crashed and set a commit status.

This error handling assumed that the ref was already fetched, resulting in a crash when that's not the case.